### PR TITLE
Add /api/agents/:id/logs activity endpoint

### DIFF
--- a/agent-command-center/backend/src/controllers/agentsController.ts
+++ b/agent-command-center/backend/src/controllers/agentsController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { getAgentById, listAgents } from "../services/agentService.js";
+import { getAgentById, getAgentLogs, listAgents } from "../services/agentService.js";
 import { logError } from "../utils/logger.js";
 
 export const getAgents = async (_req: Request, res: Response): Promise<void> => {
@@ -26,5 +26,23 @@ export const getAgent = async (req: Request, res: Response): Promise<void> => {
   } catch (error) {
     logError(`Failed to load agent ${String(req.params.id)}`, error);
     res.status(500).json({ error: "Failed to load agent" });
+  }
+};
+
+export const getAgentSessionLogs = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const agentId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const agent = await getAgentById(agentId);
+
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+
+    const logs = await getAgentLogs(agentId);
+    res.json(logs);
+  } catch (error) {
+    logError(`Failed to load logs for agent ${String(req.params.id)}`, error);
+    res.status(500).json({ error: "Failed to load agent logs" });
   }
 };

--- a/agent-command-center/backend/src/routes/agentRoutes.ts
+++ b/agent-command-center/backend/src/routes/agentRoutes.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import { getAgent, getAgents } from "../controllers/agentsController.js";
+import { getAgent, getAgentSessionLogs, getAgents } from "../controllers/agentsController.js";
 
 const agentRoutes = Router();
 
 agentRoutes.get("/agents", getAgents);
 agentRoutes.get("/agents/:id", getAgent);
+agentRoutes.get("/agents/:id/logs", getAgentSessionLogs);
 
 export default agentRoutes;

--- a/agent-command-center/backend/src/services/agentService.ts
+++ b/agent-command-center/backend/src/services/agentService.ts
@@ -1,10 +1,12 @@
 import { promises as fs } from "node:fs";
+import type { Dirent } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import type {
   AgentDetail,
   AgentIdentity,
   AgentStatus,
+  AgentLogsResponse,
   AgentSummary,
   SessionMetadata,
 } from "../types/agent.js";
@@ -160,6 +162,192 @@ export const getAgentById = async (agentId: string): Promise<AgentDetail | null>
   }
 
   return mapAgent(agentId);
+};
+
+const getTimestampFromEvent = (event: Record<string, unknown>): string | null => {
+  const timestampCandidate =
+    event.timestamp ?? event.time ?? event.createdAt ?? event.ts;
+
+  if (typeof timestampCandidate !== "string") {
+    return null;
+  }
+
+  const parsedTimestamp = Date.parse(timestampCandidate);
+  return Number.isNaN(parsedTimestamp) ? null : new Date(parsedTimestamp).toISOString();
+};
+
+const extractMessageFromEvent = (
+  event: Record<string, unknown>,
+): { role: string; content: string; timestamp: string | null } | null => {
+  const eventType = typeof event.type === "string" ? event.type.toLowerCase() : "";
+  const eventKind = typeof event.kind === "string" ? event.kind.toLowerCase() : "";
+  const eventName = typeof event.event === "string" ? event.event.toLowerCase() : "";
+
+  const isMessageLike =
+    eventType.includes("message") ||
+    eventKind.includes("message") ||
+    eventName.includes("message") ||
+    "message" in event ||
+    "content" in event ||
+    "role" in event;
+
+  if (!isMessageLike) {
+    return null;
+  }
+
+  const messageObject =
+    event.message && typeof event.message === "object"
+      ? (event.message as Record<string, unknown>)
+      : null;
+
+  const roleCandidate =
+    event.role ?? event.sender ?? event.author ?? messageObject?.role;
+  const role = typeof roleCandidate === "string" ? roleCandidate : "unknown";
+
+  if (role === "toolResult") {
+    return null;
+  }
+
+  let content: string | null = null;
+
+  if (typeof event.content === "string") {
+    content = event.content;
+  } else if (typeof event.message === "string") {
+    content = event.message;
+  } else if (typeof messageObject?.content === "string") {
+    content = messageObject.content;
+  } else if (Array.isArray(event.content)) {
+    content = event.content
+      .map((part) => {
+        if (typeof part === "string") {
+          return part;
+        }
+
+        if (
+          part &&
+          typeof part === "object" &&
+          "text" in part &&
+          typeof part.text === "string"
+        ) {
+          return part.text;
+        }
+
+        return "";
+      })
+      .join("\n")
+      .trim();
+  } else if (Array.isArray(messageObject?.content)) {
+    content = messageObject.content
+      .map((part) => {
+        if (typeof part === "string") {
+          return part;
+        }
+
+        if (
+          part &&
+          typeof part === "object" &&
+          "text" in part &&
+          typeof part.text === "string"
+        ) {
+          return part.text;
+        }
+
+        return "";
+      })
+      .join("\n")
+      .trim();
+  }
+
+  if (!content || !content.trim()) {
+    return null;
+  }
+
+  const normalizedContent = content.trim();
+
+  return {
+    role,
+    content:
+      normalizedContent.length > 2000
+        ? `${normalizedContent.slice(0, 2000)}…`
+        : normalizedContent,
+    timestamp: getTimestampFromEvent(event),
+  };
+};
+
+export const getAgentLogs = async (agentId: string): Promise<AgentLogsResponse> => {
+  const sessionsDir = path.join(AGENTS_ROOT, agentId, "sessions");
+
+  let entries: Dirent[];
+
+  try {
+    entries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  } catch (error: unknown) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return {
+        isRunning: false,
+        lastActive: null,
+        sessionId: null,
+        recentMessages: [],
+      };
+    }
+
+    throw error;
+  }
+
+  const sessionFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"));
+
+  if (sessionFiles.length === 0) {
+    return {
+      isRunning: false,
+      lastActive: null,
+      sessionId: null,
+      recentMessages: [],
+    };
+  }
+
+  const filesWithStats = await Promise.all(
+    sessionFiles.map(async (file) => {
+      const filePath = path.join(sessionsDir, file.name);
+      const stats = await fs.stat(filePath);
+      return { filePath, fileName: file.name, mtimeMs: stats.mtimeMs };
+    }),
+  );
+
+  filesWithStats.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  const latestSession = filesWithStats[0];
+  const rawSession = await fs.readFile(latestSession.filePath, "utf8");
+  const lines = rawSession.split("\n").map((line) => line.trim()).filter(Boolean);
+
+  let lastActive = new Date(latestSession.mtimeMs).toISOString();
+  const messages: AgentLogsResponse["recentMessages"] = [];
+
+  for (const line of lines) {
+    const event = safeJsonParse<Record<string, unknown>>(line);
+
+    if (!event) {
+      continue;
+    }
+
+    const eventTimestamp = getTimestampFromEvent(event);
+    if (eventTimestamp && Date.parse(eventTimestamp) > Date.parse(lastActive)) {
+      lastActive = eventTimestamp;
+    }
+
+    const message = extractMessageFromEvent(event);
+    if (message) {
+      messages.push(message);
+    }
+  }
+
+  const isRunning = Date.parse(lastActive) >= Date.now() - 10 * 60 * 1000;
+
+  return {
+    isRunning,
+    lastActive,
+    sessionId: latestSession.fileName.replace(/\.jsonl$/i, ""),
+    recentMessages: messages.slice(-50),
+  };
 };
 
 export const getAgentsRoot = (): string => AGENTS_ROOT;

--- a/agent-command-center/backend/src/types/agent.ts
+++ b/agent-command-center/backend/src/types/agent.ts
@@ -28,3 +28,16 @@ export interface SessionMetadata {
   lastActive?: string;
   status: AgentStatus;
 }
+
+export interface AgentLogMessage {
+  role: string;
+  content: string;
+  timestamp: string | null;
+}
+
+export interface AgentLogsResponse {
+  isRunning: boolean;
+  lastActive: string | null;
+  sessionId: string | null;
+  recentMessages: AgentLogMessage[];
+}


### PR DESCRIPTION
Closes #10

## Summary
- add `GET /api/agents/:id/logs`
- read latest session JSONL from `~/.openclaw/agents/{agent-name}/sessions/*.jsonl`
- parse JSONL message events from the most recent session
- return:
  - `isRunning` (true when `lastActive` is within last 10 minutes)
  - `lastActive`
  - `sessionId`
  - `recentMessages` (last 50 max)

## Implementation details
- New service method: `getAgentLogs(agentId)`
- Added controller handler: `getAgentSessionLogs`
- Added route: `/api/agents/:id/logs`
- Added backend types for logs response/message payload
- Handles missing session dir/files gracefully with empty response values
- Ignores `toolResult` messages to keep activity payload focused

## Verification
- `npm run backend:build`
- Manual smoke test:
  - `GET /api/agents/nonexistent/logs` returns 404
  - `GET /api/agents/backend-dev/logs` returns expected shape with runtime status and recent messages
