### PR TITLE
Add README.md with setup instructions

### DIFF
--- a/agent-command-center/README.md
+++ b/agent-command-center/README.md
@@ -1,0 +1,34 @@
+# Agent Command Center
+
+A local dashboard for managing OpenClaw agents.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (v18 or later recommended)
+- [npm](https://www.npmjs.com/)
+
+## Quick Start
+
+### Backend
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+The backend runs on port **3001**.
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend runs on port **5173**.
+
+---
+
+Open http://localhost:5173 in your browser to access the dashboard.


### PR DESCRIPTION
Adds a simple README with project description, prerequisites, and quick start instructions for both backend and frontend.

Closes #16