### PR TITLE
Add /api/v1/agents/runs endpoint with filtering + pagination

### DIFF
--- a/backend/src/controllers/agentsController.ts
+++ b/backend/src/controllers/agentsController.ts
@@ -1,5 +1,10 @@
 import type { Request, Response } from "express";
-import { getAgentById, listAgents } from "../services/agentService.js";
+import {
+  getAgentById,
+  listAgentRuns,
+  listAgents,
+  parseRunsQuery,
+} from "../services/agentService.js";
 import { logError } from "../utils/logger.js";
 
 export const getAgents = async (_req: Request, res: Response): Promise<void> => {
@@ -26,5 +31,26 @@ export const getAgent = async (req: Request, res: Response): Promise<void> => {
   } catch (error) {
     logError(`Failed to load agent ${String(req.params.id)}`, error);
     res.status(500).json({ error: "Failed to load agent" });
+  }
+};
+
+export const getAgentRuns = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const query = parseRunsQuery(req.query as Record<string, unknown>);
+
+    if (!query.valid) {
+      res.status(400).json({ error: query.error });
+      return;
+    }
+
+    const result = await listAgentRuns(query.value);
+    res.json({
+      data: result.data,
+      pagination: result.pagination,
+      filters: result.filters,
+    });
+  } catch (error) {
+    logError("Failed to load agent runs", error);
+    res.status(500).json({ error: "Failed to load agent runs" });
   }
 };

--- a/backend/src/routes/agentRoutes.test.ts
+++ b/backend/src/routes/agentRoutes.test.ts
@@ -1,0 +1,58 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import express from "express";
+import request from "supertest";
+import agentRoutes from "./agentRoutes.js";
+
+let tempRoot = "";
+
+before(async () => {
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), "agent-routes-test-"));
+  process.env.OPENCLAW_AGENTS_ROOT = tempRoot;
+
+  const sessionDir = path.join(tempRoot, "gamma", "sessions");
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    path.join(sessionDir, "run-1.jsonl"),
+    [
+      JSON.stringify({ timestamp: "2026-02-25T10:00:00.000Z", message: "start", status: "busy" }),
+      JSON.stringify({ timestamp: "2026-02-25T10:01:00.000Z", message: "done", status: "idle" }),
+    ].join("\n"),
+    "utf8",
+  );
+});
+
+after(async () => {
+  delete process.env.OPENCLAW_AGENTS_ROOT;
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe("GET /api/v1/agents/runs", () => {
+  it("returns run history with pagination", async () => {
+    const app = express();
+    app.use("/api", agentRoutes);
+
+    const response = await request(app).get("/api/v1/agents/runs?limit=10&offset=0");
+
+    assert.equal(response.status, 200);
+    assert.equal(Array.isArray(response.body.data), true);
+    assert.equal(response.body.pagination.total, 1);
+    assert.equal(response.body.data[0].agent, "gamma");
+    assert.equal(typeof response.body.data[0].logs, "string");
+  });
+
+  it("validates bad query params", async () => {
+    const app = express();
+    app.use("/api", agentRoutes);
+
+    const response = await request(app).get("/api/v1/agents/runs?status=not-real");
+
+    assert.equal(response.status, 400);
+    assert.match(response.body.error, /Invalid 'status'/);
+  });
+});

--- a/backend/src/routes/agentRoutes.ts
+++ b/backend/src/routes/agentRoutes.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import { getAgent, getAgents } from "../controllers/agentsController.js";
+import { getAgent, getAgentRuns, getAgents } from "../controllers/agentsController.js";
 
 const agentRoutes = Router();
 
 agentRoutes.get("/agents", getAgents);
 agentRoutes.get("/agents/:id", getAgent);
+agentRoutes.get("/v1/agents/runs", getAgentRuns);
 
 export default agentRoutes;

--- a/backend/src/services/agentService.test.ts
+++ b/backend/src/services/agentService.test.ts
@@ -1,0 +1,107 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { listAgentRuns, parseRunsQuery } from "./agentService.js";
+
+let tempRoot = "";
+
+const writeSession = async (
+  agentId: string,
+  fileName: string,
+  lines: Array<Record<string, unknown>>,
+): Promise<void> => {
+  const sessionDir = path.join(tempRoot, agentId, "sessions");
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    path.join(sessionDir, fileName),
+    `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+};
+
+before(async () => {
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), "agent-runs-test-"));
+  process.env.OPENCLAW_AGENTS_ROOT = tempRoot;
+
+  await writeSession("alpha", "run-1.jsonl", [
+    { timestamp: "2026-02-20T10:00:00.000Z", message: "started", status: "busy" },
+    { timestamp: "2026-02-20T10:03:00.000Z", message: "completed", status: "idle" },
+  ]);
+
+  await writeSession("alpha", "run-2.jsonl", [
+    { timestamp: "2026-02-21T12:00:00.000Z", message: "started", status: "busy" },
+    { timestamp: "2026-02-21T12:01:00.000Z", level: "error", message: "failed" },
+  ]);
+
+  await writeSession("beta", "run-1.jsonl", [
+    { timestamp: "2026-02-22T09:00:00.000Z", message: "started", status: "busy" },
+    { timestamp: "2026-02-22T09:05:00.000Z", message: "still running", status: "busy" },
+  ]);
+});
+
+after(async () => {
+  delete process.env.OPENCLAW_AGENTS_ROOT;
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+describe("parseRunsQuery", () => {
+  it("accepts valid query params", () => {
+    const result = parseRunsQuery({
+      agent: "alpha",
+      from: "2026-02-20T00:00:00.000Z",
+      to: "2026-02-23T00:00:00.000Z",
+      status: "idle",
+      limit: "10",
+      offset: "2",
+    });
+
+    assert.equal(result.valid, true);
+    if (result.valid) {
+      assert.deepEqual(result.value, {
+        agent: "alpha",
+        from: "2026-02-20T00:00:00.000Z",
+        to: "2026-02-23T00:00:00.000Z",
+        status: "idle",
+        limit: 10,
+        offset: 2,
+      });
+    }
+  });
+
+  it("rejects invalid status", () => {
+    const result = parseRunsQuery({ status: "done" });
+    assert.equal(result.valid, false);
+  });
+});
+
+describe("listAgentRuns", () => {
+  it("returns paginated runs with metadata and logs", async () => {
+    const query = parseRunsQuery({ limit: "2", offset: "0" });
+    assert.equal(query.valid, true);
+    if (!query.valid) return;
+
+    const result = await listAgentRuns(query.value);
+
+    assert.equal(result.pagination.total, 3);
+    assert.equal(result.data.length, 2);
+    assert.ok(result.data[0].id);
+    assert.ok(result.data[0].agent);
+    assert.ok(typeof result.data[0].logs === "string");
+  });
+
+  it("filters by agent and status", async () => {
+    const query = parseRunsQuery({ agent: "alpha", status: "error", limit: "50" });
+    assert.equal(query.valid, true);
+    if (!query.valid) return;
+
+    const result = await listAgentRuns(query.value);
+
+    assert.equal(result.data.length, 1);
+    assert.equal(result.data[0].agent, "alpha");
+    assert.equal(result.data[0].status, "error");
+  });
+});

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -4,12 +4,19 @@ import os from "node:os";
 import type {
   AgentDetail,
   AgentIdentity,
+  AgentRun,
+  AgentRunsQuery,
   AgentStatus,
   AgentSummary,
   SessionMetadata,
 } from "../types/agent.js";
 
-const AGENTS_ROOT = path.join(os.homedir(), ".openclaw", "agents");
+const DEFAULT_AGENTS_ROOT = path.join(os.homedir(), ".openclaw", "agents");
+const DEFAULT_RUN_LIMIT = 50;
+const MAX_RUN_LIMIT = 200;
+const LOG_TRUNCATE_LIMIT = 8000;
+
+const getConfiguredAgentsRoot = (): string => process.env.OPENCLAW_AGENTS_ROOT ?? DEFAULT_AGENTS_ROOT;
 
 const isAgentStatus = (value: unknown): value is AgentStatus =>
   value === "idle" || value === "busy" || value === "error";
@@ -117,7 +124,7 @@ const parseSessionMetadata = async (sessionsDir: string): Promise<SessionMetadat
 };
 
 const mapAgent = async (agentId: string): Promise<AgentDetail> => {
-  const agentDir = path.join(AGENTS_ROOT, agentId);
+  const agentDir = path.join(getConfiguredAgentsRoot(), agentId);
   const identity = await readIdentity(agentDir);
   const sessionDir = path.join(agentDir, "sessions");
   const sessionMeta = await parseSessionMetadata(sessionDir);
@@ -139,8 +146,157 @@ const mapAgent = async (agentId: string): Promise<AgentDetail> => {
   };
 };
 
+interface ParsedEvent {
+  timestamp?: string;
+  status?: AgentStatus;
+  level?: string;
+  message?: string;
+  raw: string;
+}
+
+const parseEventLine = (line: string): ParsedEvent | null => {
+  const parsed = safeJsonParse<Record<string, unknown>>(line);
+
+  if (!parsed) {
+    return { raw: line };
+  }
+
+  const timestampCandidate = parsed.timestamp ?? parsed.time ?? parsed.createdAt;
+  const statusCandidate = parsed.status ?? parsed.state;
+
+  return {
+    timestamp: typeof timestampCandidate === "string" ? timestampCandidate : undefined,
+    status: isAgentStatus(statusCandidate) ? statusCandidate : undefined,
+    level: typeof parsed.level === "string" ? parsed.level : undefined,
+    message: typeof parsed.message === "string" ? parsed.message : undefined,
+    raw: line,
+  };
+};
+
+const statusFromEvents = (events: ParsedEvent[]): AgentStatus => {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (event.status) {
+      return event.status;
+    }
+    if (event.level === "error") {
+      return "error";
+    }
+  }
+
+  return events.length > 0 ? "busy" : "idle";
+};
+
+const truncateLogs = (logOutput: string): string => {
+  if (logOutput.length <= LOG_TRUNCATE_LIMIT) {
+    return logOutput;
+  }
+
+  return `${logOutput.slice(0, LOG_TRUNCATE_LIMIT)}\n...[truncated]`;
+};
+
+const readRunFromSessionFile = async (agentId: string, sessionsDir: string, fileName: string): Promise<AgentRun> => {
+  const filePath = path.join(sessionsDir, fileName);
+  const content = await fs.readFile(filePath, "utf8");
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const events = lines
+    .map((line) => parseEventLine(line))
+    .filter((event): event is ParsedEvent => event !== null);
+
+  const startedAt = events.find((event) => typeof event.timestamp === "string")?.timestamp;
+  const completedAt = [...events]
+    .reverse()
+    .find((event) => typeof event.timestamp === "string")?.timestamp;
+  const logs = truncateLogs(
+    events
+      .map((event) => event.message ?? event.raw)
+      .filter(Boolean)
+      .join("\n"),
+  );
+
+  return {
+    id: `${agentId}:${fileName}`,
+    agent: agentId,
+    started_at: startedAt,
+    completed_at: completedAt,
+    status: statusFromEvents(events),
+    logs,
+  };
+};
+
+const toComparableTime = (value?: string): number => {
+  if (!value) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+const parsePositiveInt = (value: unknown): number | null => {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+
+  return parsed;
+};
+
+export const parseRunsQuery = (
+  query: Record<string, unknown>,
+): { valid: true; value: AgentRunsQuery } | { valid: false; error: string } => {
+  const agent = typeof query.agent === "string" && query.agent.trim() !== "" ? query.agent.trim() : undefined;
+  const from = typeof query.from === "string" && query.from.trim() !== "" ? query.from.trim() : undefined;
+  const to = typeof query.to === "string" && query.to.trim() !== "" ? query.to.trim() : undefined;
+  const statusCandidate = typeof query.status === "string" ? query.status : undefined;
+
+  if (from && Number.isNaN(Date.parse(from))) {
+    return { valid: false, error: "Invalid 'from' date" };
+  }
+
+  if (to && Number.isNaN(Date.parse(to))) {
+    return { valid: false, error: "Invalid 'to' date" };
+  }
+
+  if (statusCandidate && !isAgentStatus(statusCandidate)) {
+    return { valid: false, error: "Invalid 'status'. Must be one of: idle, busy, error" };
+  }
+
+  const status = statusCandidate && isAgentStatus(statusCandidate) ? statusCandidate : undefined;
+
+  const parsedLimit = parsePositiveInt(query.limit);
+  const parsedOffset = parsePositiveInt(query.offset);
+
+  const limit = parsedLimit ?? DEFAULT_RUN_LIMIT;
+  const offset = parsedOffset ?? 0;
+
+  if (limit < 1 || limit > MAX_RUN_LIMIT) {
+    return { valid: false, error: `Invalid 'limit'. Must be between 1 and ${MAX_RUN_LIMIT}` };
+  }
+
+  return {
+    valid: true,
+    value: {
+      agent,
+      from,
+      to,
+      status,
+      limit,
+      offset,
+    },
+  };
+};
+
 export const listAgents = async (): Promise<AgentSummary[]> => {
-  const entries = await fs.readdir(AGENTS_ROOT, { withFileTypes: true });
+  const entries = await fs.readdir(getConfiguredAgentsRoot(), { withFileTypes: true });
   const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
 
   const details = await Promise.all(dirs.map((id) => mapAgent(id)));
@@ -148,7 +304,7 @@ export const listAgents = async (): Promise<AgentSummary[]> => {
 };
 
 export const getAgentById = async (agentId: string): Promise<AgentDetail | null> => {
-  const agentDir = path.join(AGENTS_ROOT, agentId);
+  const agentDir = path.join(getConfiguredAgentsRoot(), agentId);
 
   try {
     const stats = await fs.stat(agentDir);
@@ -162,4 +318,75 @@ export const getAgentById = async (agentId: string): Promise<AgentDetail | null>
   return mapAgent(agentId);
 };
 
-export const getAgentsRoot = (): string => AGENTS_ROOT;
+export const listAgentRuns = async (query: AgentRunsQuery): Promise<{
+  data: AgentRun[];
+  pagination: { limit: number; offset: number; total: number };
+  filters: { agent?: string; from?: string; to?: string; status?: AgentStatus };
+}> => {
+  const entries = await fs.readdir(getConfiguredAgentsRoot(), { withFileTypes: true });
+  const agentIds = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((id) => (query.agent ? id === query.agent : true));
+
+  const runs: AgentRun[] = [];
+
+  for (const agentId of agentIds) {
+    const sessionsDir = path.join(getConfiguredAgentsRoot(), agentId, "sessions");
+    let sessionEntries;
+
+    try {
+      sessionEntries = await fs.readdir(sessionsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    const sessionFiles = sessionEntries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+      .map((entry) => entry.name);
+
+    const agentRuns = await Promise.all(
+      sessionFiles.map(async (fileName) => readRunFromSessionFile(agentId, sessionsDir, fileName)),
+    );
+
+    runs.push(...agentRuns);
+  }
+
+  const filtered = runs.filter((run) => {
+    if (query.status && run.status !== query.status) {
+      return false;
+    }
+
+    const started = toComparableTime(run.started_at ?? run.completed_at);
+    if (query.from && started < toComparableTime(query.from)) {
+      return false;
+    }
+
+    if (query.to && started > toComparableTime(query.to)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  filtered.sort((a, b) => toComparableTime(b.started_at ?? b.completed_at) - toComparableTime(a.started_at ?? a.completed_at));
+
+  const paginated = filtered.slice(query.offset, query.offset + query.limit);
+
+  return {
+    data: paginated,
+    pagination: {
+      limit: query.limit,
+      offset: query.offset,
+      total: filtered.length,
+    },
+    filters: {
+      agent: query.agent,
+      from: query.from,
+      to: query.to,
+      status: query.status,
+    },
+  };
+};
+
+export const getAgentsRoot = (): string => getConfiguredAgentsRoot();

--- a/backend/src/types/agent.ts
+++ b/backend/src/types/agent.ts
@@ -28,3 +28,23 @@ export interface SessionMetadata {
   lastActive?: string;
   status: AgentStatus;
 }
+
+export type RunStatus = AgentStatus;
+
+export interface AgentRun {
+  id: string;
+  agent: string;
+  started_at?: string;
+  completed_at?: string;
+  status: RunStatus;
+  logs: string;
+}
+
+export interface AgentRunsQuery {
+  agent?: string;
+  from?: string;
+  to?: string;
+  status?: RunStatus;
+  limit: number;
+  offset: number;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@types/supertest": "^6.0.3",
         "@vitejs/plugin-react": "^5.1.1",
         "autoprefixer": "^10.4.24",
         "eslint": "^9.39.1",
@@ -32,6 +33,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "postcss": "^8.5.6",
+        "supertest": "^7.1.4",
         "tailwindcss": "^4.2.0",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3",
@@ -1035,6 +1037,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1729,6 +1754,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -1782,6 +1814,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1858,6 +1897,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2239,6 +2302,20 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
@@ -2483,6 +2560,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2540,6 +2640,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -2604,6 +2711,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2621,6 +2738,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -2698,6 +2826,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3040,6 +3184,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3129,6 +3280,64 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3306,6 +3515,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3908,6 +4133,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -4680,6 +4928,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "backend:dev": "tsx watch backend/src/index.ts",
     "backend:build": "tsc -p backend/tsconfig.json",
-    "backend:start": "node backend/dist/index.js"
+    "backend:start": "node backend/dist/index.js",
+    "backend:test": "node --test --import tsx backend/src/**/*.test.ts"
   },
   "dependencies": {
     "cors": "^2.8.6",
@@ -30,6 +31,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@types/supertest": "^6.0.3",
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.24",
     "eslint": "^9.39.1",
@@ -37,6 +39,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "postcss": "^8.5.6",
+    "supertest": "^7.1.4",
     "tailwindcss": "^4.2.0",
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",


### PR DESCRIPTION
## Summary
- add `GET /api/v1/agents/runs` to return recent agent run history with log output
- support query params: `agent`, `from`, `to`, `status`, `limit`, `offset`
- validate query parameters and return `400` for invalid inputs
- include pagination metadata and applied filters in the response
- derive run metadata (`id`, `agent`, `started_at`, `completed_at`, `status`) from session JSONL files
- add log truncation guard for very large outputs

## Testing
- `npm run backend:build`
- `npm run backend:test`

## Notes
- added `OPENCLAW_AGENTS_ROOT` env override to make backend run/log tests deterministic
- added endpoint integration test and service-level tests for query parsing/filtering

Fixes #22