### PR TITLE
Add fetch network logging with safe header redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ npm run backend:build
 npm run backend:start
 ```
 
+## Frontend network logging
+
+The frontend installs a global `fetch` logger that prints request/response details to the browser console:
+
+- method, URL, headers, payload
+- status, response headers, response body
+- ISO timestamp + request duration
+- sensitive headers (for example `Authorization`, `Cookie`, `X-Api-Key`) are redacted
+
+Enable/disable behavior:
+
+- `development`: enabled by default
+- `production`: disabled by default
+- override with env var `VITE_ENABLE_NETWORK_LOGGING=true|false`
+
 ## Notes
 
 If `~/.openclaw/agents/` does not exist or is unreadable, API requests will return an error response.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { installFetchNetworkLogger } from './utils/networkLogger.ts'
+
+installFetchNetworkLogger()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/utils/networkLogger.test.ts
+++ b/src/utils/networkLogger.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __networkLoggerTestUtils, installFetchNetworkLogger } from './networkLogger';
+
+describe('network logger', () => {
+  const originalFetch = window.fetch;
+  const originalEnvFlag = import.meta.env.VITE_ENABLE_NETWORK_LOGGING;
+
+  beforeEach(() => {
+    __networkLoggerTestUtils.resetInstalled();
+    (import.meta.env as Record<string, string | boolean | undefined>).VITE_ENABLE_NETWORK_LOGGING = 'true';
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    (import.meta.env as Record<string, string | boolean | undefined>).VITE_ENABLE_NETWORK_LOGGING = originalEnvFlag;
+    vi.restoreAllMocks();
+  });
+
+  it('redacts sensitive headers', () => {
+    const headers = __networkLoggerTestUtils.toHeaderRecord({
+      Authorization: 'Bearer token',
+      'X-Api-Key': 'secret',
+      'Content-Type': 'application/json',
+    });
+
+    expect(headers).toEqual({
+      authorization: '[REDACTED]',
+      'x-api-key': '[REDACTED]',
+      'content-type': 'application/json',
+    });
+  });
+
+  it('logs request and response without consuming response body', async () => {
+    const payload = { ok: true, value: 42 };
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    window.fetch = fetchSpy as typeof window.fetch;
+
+    const groupSpy = vi.spyOn(console, 'groupCollapsed').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const groupEndSpy = vi.spyOn(console, 'groupEnd').mockImplementation(() => {});
+
+    installFetchNetworkLogger();
+
+    const response = await fetch('/api/test', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abc',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'forge' }),
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(payload);
+
+    expect(groupSpy).toHaveBeenCalledWith('🌐 HTTP Request POST /api/test');
+    expect(logSpy).toHaveBeenCalledWith(
+      'request',
+      expect.objectContaining({
+        method: 'POST',
+        url: '/api/test',
+        headers: expect.objectContaining({
+          authorization: '[REDACTED]',
+          'content-type': 'application/json',
+        }),
+        payload: { name: 'forge' },
+      }),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      'response',
+      expect.objectContaining({
+        status: 200,
+        body: payload,
+      }),
+    );
+    expect(groupEndSpy).toHaveBeenCalled();
+  });
+});

--- a/src/utils/networkLogger.ts
+++ b/src/utils/networkLogger.ts
@@ -1,0 +1,178 @@
+const REDACTED_VALUE = '[REDACTED]';
+
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'proxy-authorization',
+  'x-api-key',
+  'x-auth-token',
+]);
+
+let fetchLoggerInstalled = false;
+
+const toHeaderRecord = (headers?: HeadersInit): Record<string, string> => {
+  if (!headers) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  const appendHeader = (key: string, value: string) => {
+    result[key.toLowerCase()] = SENSITIVE_HEADER_NAMES.has(key.toLowerCase()) ? REDACTED_VALUE : value;
+  };
+
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => appendHeader(key, value));
+    return result;
+  }
+
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      appendHeader(key, value);
+    }
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      appendHeader(key, value.join(', '));
+      continue;
+    }
+
+    if (value !== undefined) {
+      appendHeader(key, String(value));
+    }
+  }
+
+  return result;
+};
+
+const safeJsonParse = (value: string): unknown => {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+};
+
+const readRequestBody = (init?: RequestInit): unknown => {
+  if (!init?.body) {
+    return undefined;
+  }
+
+  if (typeof init.body === 'string') {
+    return safeJsonParse(init.body);
+  }
+
+  if (init.body instanceof URLSearchParams) {
+    return Object.fromEntries(init.body.entries());
+  }
+
+  if (init.body instanceof FormData) {
+    return Object.fromEntries(init.body.entries());
+  }
+
+  if (init.body instanceof Blob) {
+    return `[Blob ${init.body.type || 'application/octet-stream'} (${init.body.size} bytes)]`;
+  }
+
+  if (init.body instanceof ArrayBuffer) {
+    return `[ArrayBuffer (${init.body.byteLength} bytes)]`;
+  }
+
+  if (ArrayBuffer.isView(init.body)) {
+    return `[TypedArray (${init.body.byteLength} bytes)]`;
+  }
+
+  return String(init.body);
+};
+
+const readResponseBody = async (response: Response): Promise<unknown> => {
+  try {
+    const text = await response.clone().text();
+
+    if (!text) {
+      return null;
+    }
+
+    return safeJsonParse(text);
+  } catch {
+    return '[Unreadable response body]';
+  }
+};
+
+const shouldEnableLogging = (): boolean => {
+  const explicitFlag = import.meta.env.VITE_ENABLE_NETWORK_LOGGING;
+  if (explicitFlag === 'true') {
+    return true;
+  }
+
+  if (explicitFlag === 'false') {
+    return false;
+  }
+
+  return import.meta.env.DEV;
+};
+
+const nowIso = (): string => new Date().toISOString();
+
+export const installFetchNetworkLogger = (): void => {
+  if (fetchLoggerInstalled || typeof window === 'undefined' || !shouldEnableLogging()) {
+    return;
+  }
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const timestamp = nowIso();
+    const startedAt = performance.now();
+
+    const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+    const url = input instanceof Request ? input.url : String(input);
+    const headers = toHeaderRecord(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+
+    console.groupCollapsed(`🌐 HTTP Request ${method.toUpperCase()} ${url}`);
+    console.log('timestamp', timestamp);
+    console.log('request', {
+      method: method.toUpperCase(),
+      url,
+      headers,
+      payload: readRequestBody(init),
+    });
+
+    try {
+      const response = await originalFetch(input, init);
+      const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+      const responseBody = await readResponseBody(response);
+
+      console.log('response', {
+        status: response.status,
+        statusText: response.statusText,
+        headers: toHeaderRecord(response.headers),
+        body: responseBody,
+        durationMs,
+      });
+      console.groupEnd();
+
+      return response;
+    } catch (error) {
+      const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+      console.error('response_error', {
+        error,
+        durationMs,
+      });
+      console.groupEnd();
+      throw error;
+    }
+  };
+
+  fetchLoggerInstalled = true;
+};
+
+export const __networkLoggerTestUtils = {
+  toHeaderRecord,
+  shouldEnableLogging,
+  resetInstalled: () => {
+    fetchLoggerInstalled = false;
+  },
+};


### PR DESCRIPTION
## Summary
- add a global frontend `fetch` interceptor that logs every request/response to the browser console
- include method, URL, headers, payload, status, response headers/body, timestamp, and request duration
- pretty-print JSON payload/response objects and avoid consuming response bodies by reading via `response.clone()`
- redact sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, etc.)
- gate logging behind config: enabled by default in dev, disabled by default in prod, overridable via `VITE_ENABLE_NETWORK_LOGGING=true|false`

## Validation
- `npm test -- --run`
- `npm run build`

## Notes
- added unit tests for header redaction and request/response logging behavior
- documented logging behavior and env toggle in `README.md`

Fixes #34