### PR TITLE
Fix /api/agents to return agents from openclaw.json

### DIFF
--- a/backend/src/controllers/agentsController.ts
+++ b/backend/src/controllers/agentsController.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import {
   getAgentById,
   listAgentRuns,
-  listAgents,
+  listAgentsFromConfig,
   listAgentSkills,
   parseRunsQuery,
 } from "../services/agentService.js";
@@ -10,10 +10,10 @@ import { logError } from "../utils/logger.js";
 
 export const getAgents = async (_req: Request, res: Response): Promise<void> => {
   try {
-    const agents = await listAgents();
-    res.json({ data: agents });
+    const agents = await listAgentsFromConfig();
+    res.json(agents);
   } catch (error) {
-    logError("Failed to load agents", error);
+    logError("Failed to load agents from openclaw config", error);
     res.status(500).json({ error: "Failed to load agents" });
   }
 };

--- a/backend/src/routes/agentRoutes.test.ts
+++ b/backend/src/routes/agentRoutes.test.ts
@@ -20,6 +20,13 @@ before(async () => {
 
   process.env.OPENCLAW_ROOT = tempRoot;
   process.env.OPENCLAW_AGENTS_ROOT = tempRoot;
+  process.env.OPENCLAW_CONFIG_PATH = path.join(tempRoot, "openclaw.json");
+
+  await writeFile(
+    process.env.OPENCLAW_CONFIG_PATH,
+    JSON.stringify({ agents: ["main", "backend-dev", "research"] }, null, 2),
+    "utf8",
+  );
 
   const skillsRoot = path.join(tempRoot, "workspace-bravo", "skills", "route-skill");
   await mkdir(skillsRoot, { recursive: true });
@@ -44,9 +51,31 @@ before(async () => {
 after(async () => {
   delete process.env.OPENCLAW_ROOT;
   delete process.env.OPENCLAW_AGENTS_ROOT;
+  delete process.env.OPENCLAW_CONFIG_PATH;
   if (tempRoot) {
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+describe("GET /api/agents", () => {
+  it("returns agent list from openclaw.json", async () => {
+    const response = await request(buildApp()).get("/api/agents");
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body, ["main", "backend-dev", "research"]);
+  });
+
+  it("returns 500 when config cannot be read", async () => {
+    const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = path.join(tempRoot, "missing-openclaw.json");
+
+    const response = await request(buildApp()).get("/api/agents");
+
+    process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+
+    assert.equal(response.status, 500);
+    assert.equal(response.body.error, "Failed to load agents");
+  });
 });
 
 describe("GET /api/v1/agents/:id/skills", () => {

--- a/backend/src/services/agentService.ts
+++ b/backend/src/services/agentService.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types/agent.js";
 
 const DEFAULT_OPENCLAW_ROOT = path.join(os.homedir(), ".openclaw");
+const DEFAULT_OPENCLAW_CONFIG_PATH = path.join(DEFAULT_OPENCLAW_ROOT, "openclaw.json");
 const DEFAULT_AGENTS_ROOT = path.join(DEFAULT_OPENCLAW_ROOT, "agents");
 const MAIN_AGENT_ID = "main";
 const MAIN_SKILLS_ROOT = "/workspace/skills";
@@ -22,6 +23,8 @@ const MAX_RUN_LIMIT = 200;
 const LOG_TRUNCATE_LIMIT = 8000;
 
 const getConfiguredOpenclawRoot = (): string => process.env.OPENCLAW_ROOT ?? DEFAULT_OPENCLAW_ROOT;
+const getConfiguredOpenclawConfigPath = (): string =>
+  process.env.OPENCLAW_CONFIG_PATH ?? DEFAULT_OPENCLAW_CONFIG_PATH;
 const getConfiguredAgentsRoot = (): string => process.env.OPENCLAW_AGENTS_ROOT ?? DEFAULT_AGENTS_ROOT;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -302,6 +305,18 @@ export const parseRunsQuery = (
       offset,
     },
   };
+};
+
+export const listAgentsFromConfig = async (): Promise<unknown[]> => {
+  const configPath = getConfiguredOpenclawConfigPath();
+  const configContent = await fs.readFile(configPath, "utf8");
+  const parsed = safeJsonParse<Record<string, unknown>>(configContent);
+
+  if (!parsed || !Array.isArray(parsed.agents)) {
+    return [];
+  }
+
+  return parsed.agents;
 };
 
 export const listAgents = async (): Promise<AgentSummary[]> => {


### PR DESCRIPTION
## Summary
- updated GET /api/agents to read from openclaw.json instead of scanning agent directories
- added config path resolution with OPENCLAW_CONFIG_PATH override and default ~/.openclaw/openclaw.json
- returns the agents array directly from config
- preserves graceful error handling by returning 500 when config read fails

## Tests
- added route tests for GET /api/agents success path (returns config agents)
- added route test for config read failure (returns 500)
- ran: npm run backend:test

Fixes #36